### PR TITLE
Various bug fixes and improvements (28 March 2013)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- WARNING: Eclipse auto-generated file.
+              Any modifications will be overwritten.
+              To include a user specific buildfile here, simply create one in the same
+              directory with the processing instruction <?eclipse.ant.import?>
+              as the first entry and export the buildfile again. -->
+<project basedir="." default="build" name="iDynoMiCS">
+    <property environment="env"/>
+    <property name="ECLIPSE_HOME" value="../../../../Applications/eclipse"/>
+    <property name="debuglevel" value="source,lines,vars"/>
+    <property name="target" value="1.6"/>
+    <property name="source" value="1.6"/>
+    <path id="iDynoMiCS.classpath">
+        <pathelement location="bin"/>
+        <pathelement location="src/lib/Jama-1.0.2.jar"/>
+        <pathelement location="src/lib/jcommon-1.0.12.jar"/>
+        <pathelement location="src/lib/jdom.jar"/>
+        <pathelement location="src/lib/jfreechart-1.0.9.jar"/>
+        <pathelement location="src/lib/truezip-6.jar"/>
+    </path>
+    <target name="init">
+        <mkdir dir="bin"/>
+        <copy includeemptydirs="false" todir="bin">
+            <fileset dir="src">
+                <exclude name="**/*.java"/>
+            </fileset>
+        </copy>
+    </target>
+    <target name="clean">
+        <delete dir="bin"/>
+    </target>
+    <target depends="clean" name="cleanall"/>
+    <target depends="build-subprojects,build-project" name="build"/>
+    <target name="build-subprojects"/>
+    <target depends="init" name="build-project">
+        <echo message="${ant.project.name}: ${ant.file}"/>
+        <javac debug="true" debuglevel="${debuglevel}" destdir="bin" source="${source}" target="${target}" encoding="iso-8859-1">
+            <src path="src"/>
+            <classpath refid="iDynoMiCS.classpath"/>
+        </javac>
+    </target>
+    <target description="Build all projects which reference this project. Useful to propagate changes." name="build-refprojects"/>
+    <target description="copy Eclipse compiler jars to ant lib directory" name="init-eclipse-compiler">
+        <copy todir="${ant.library.dir}">
+            <fileset dir="${ECLIPSE_HOME}/plugins" includes="org.eclipse.jdt.core_*.jar"/>
+        </copy>
+        <unzip dest="${ant.library.dir}">
+            <patternset includes="jdtCompilerAdapter.jar"/>
+            <fileset dir="${ECLIPSE_HOME}/plugins" includes="org.eclipse.jdt.core_*.jar"/>
+        </unzip>
+    </target>
+    <target description="compile project with Eclipse compiler" name="build-eclipse-compiler">
+        <property name="build.compiler" value="org.eclipse.jdt.core.JDTCompilerAdapter"/>
+        <antcall target="build"/>
+    </target>
+    <target name="Idynomics (1)">
+        <java classname="idyno.Idynomics" failonerror="true" fork="yes">
+            <classpath refid="iDynoMiCS.classpath"/>
+        </java>
+    </target>
+</project>

--- a/results_analysis_matlab/routines2D/createPics.m
+++ b/results_analysis_matlab/routines2D/createPics.m
@@ -28,7 +28,9 @@ imPATH    = getProgramPath('ImageMagick');
 
 % Start POV-Ray
 %eval(['!',POVPATH,'pvengine &']);
-dos(sprintf('"%s\\pvengine.exe" &',POVPATH));
+if ispc
+    dos(sprintf('"%s\\pvengine.exe" &',POVPATH));
+end
 
 pause(1);
 
@@ -107,9 +109,12 @@ fprintf('Rendering file %s\n',theFile);
 %dos([QuietPATH,'quietpov -start ',theFile]);
 %dos(sprintf('"%s\\quietpov" -start %s',QuietPATH,theFile));
 
-
- dos(sprintf('"%s\\pvengine.exe" /RENDER %s', POVPATH, theFile));
- pause(5)
+if ispc
+    dos(sprintf('"%s\\pvengine.exe" /RENDER %s', POVPATH, theFile));
+elseif isunix
+    unix(sprintf('povray "%s"', theFile));
+end
+pause(5)
     
 bmp2png(theFile);
 
@@ -123,7 +128,10 @@ if isnumeric(nFile)
 else
     newName = 'it(last).png';
 	% moves the image file into the base directory
-	movefile('lastIter/it(last).png','.');
+    % if it isn't there already
+    if exist('lastIter/it(last).png','file')
+    	movefile('lastIter/it(last).png','.');
+    end
 end
 
 imgfile = newName;
@@ -133,16 +141,25 @@ imgfile = newName;
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function bmp2png(povfile)
 % this converts the output .bmp file to .png if it doesn't exist
-
 global imPATH;
 
-bmpfile = strrep(povfile,'pov','bmp');
-pngfile = strrep(povfile,'pov','png');
+[pathstr, name, ~] = fileparts(povfile);
+bmpfile = strrep(pathstr, name,'.bmp');
+if ~exist(bmpfile,'file')
+    bmpfile = strcat(name,'.bmp');
+end
+pngfile = strrep(pathstr, name,'.png');
+if ~exist(pngfile,'file')
+    pngfile = strcat(name,'.png');
+end
 
 if ~exist(pngfile,'file')
 	% now call the convert command to convert the image
-	dos(sprintf('"%s\\convert" %s  %s',...
-		imPATH,bmpfile,pngfile));
+    if ispc
+    	dos(sprintf('"%s\\convert" %s  %s', imPATH,bmpfile,pngfile));
+    elseif isunix
+        unix(sprintf('%s/convert "%s" "%s"', imPATH, bmpfile, pngfile));
+    end
 	delete(bmpfile);
 end
 

--- a/results_analysis_matlab/routines2D/utilities/getProgramPath.m
+++ b/results_analysis_matlab/routines2D/utilities/getProgramPath.m
@@ -5,21 +5,41 @@ function thepath = getProgramPath(theprog)
 
 theprog = lower(theprog);
 
+if ~ispc && ~isunix
+    fprintf('Warning: operating system not recognised')
+end
+
 if strcmp(theprog,'POV-Ray')
 	% install location for POV-Ray
-	thepath = 'C:\Program Files (x86)\POV-Ray\v3.6\bin\';
+    if ispc
+    	thepath = 'C:\Program Files (x86)\POV-Ray\v3.6\bin\';
+    elseif isunix
+        thepath = '/usr/local/bin/';
+    end
 
 elseif strcmp(theprog,'quietpov')
 	% install location for the QuietPOV add-on
-	thepath = 'C:\Program Files\POV-Ray for Windows v3.6\guiext\QuietPOV';
+    if ispc
+    	thepath = 'C:\Program Files\POV-Ray for Windows v3.6\guiext\QuietPOV';
+    elseif isunix
+        thepath = '';
+    end
 
 elseif strcmp(theprog,'imagemagick')
 	% install location for ImageMagick
-	thepath = 'C:\Program Files\ImageMagick-6.6.9-Q16';
+    if ispc
+    	thepath = 'C:\Program Files\ImageMagick-6.6.9-Q16';
+    elseif isunix
+        thepath = '/usr/share/ImageMagick-6.6.9';
+    end
 
 elseif strcmp(theprog,'ffmpeg')
 	% install location for the ffmpeg library
-	thepath = 'D:\models\eclipse_workspace\idynomics\software_utilities\ffmpeg';
+    if ispc
+    	thepath = 'D:\models\eclipse_workspace\idynomics\software_utilities\ffmpeg';
+    elseif isunix
+        thepath = '/usr/bin/ffmpeg';
+    end 
 
 else
 	thepath = '';

--- a/src/simulator/Simulator.java
+++ b/src/simulator/Simulator.java
@@ -143,11 +143,9 @@ public class Simulator {
 			// Describe initial conditions
 			if (!Simulator.isChemostat)
 				povRayWriter.write(SimTimer.getCurrentIter());
-			//if (invComp) {
-			//	writeInvReport();
-			//} else {
+			
 			writeReport();
-			//}
+			
 
 		} catch (Exception e) {
 			LogFile.writeLog("Simulator.CreateSystem(): error met: "+e);
@@ -570,7 +568,7 @@ public class Simulator {
 		}
 
 		System.out.println("\t done");
-		}catch(Exception e){LogFile.writeLog("Error in Simulator.creatSolvers()");}
+		}catch(Exception e){LogFile.writeLog("Error in Simulator.creatSolvers(): "+e);}
 	}
 
 	/**
@@ -833,29 +831,6 @@ public class Simulator {
 
 	}
 
-	public void writeInvReport() {
-		// Update saving counters and file index
-		_lastOutput = SimTimer.getCurrentTime();
-		int currentIter = SimTimer.getCurrentIter(); // bvm added 26.1.2009
-
-		// first restart log file to avoid non-write trouble
-		LogFile.reopenFile();
-		try {
-			result[0].openFile(currentIter); // agent_
-			result[1].openFile(currentIter); // agent_
-
-			agentGrid.writeReport(this, result[0], result[1]);
-
-			result[0].closeFile();
-			result[1].closeFile();
-
-		} catch (Exception e) {
-			LogFile.writeError("System description of agents failed:"+e.getMessage(),
-			"Simulator.writeReport()");
-		}
-
-
-	}
 
 	/* ____________________ ACCESSORS & MUTATORS ___________________________ */
 	/**

--- a/src/simulator/World.java
+++ b/src/simulator/World.java
@@ -17,6 +17,7 @@ package simulator;
 import java.util.*;
 
 import utils.ExtraMath;
+import utils.LogFile;
 import utils.XMLParser;
 import simulator.geometry.*;
 
@@ -33,13 +34,21 @@ public class World {
 	 */
 
 	public void init(Simulator aSim, XMLParser worldRoot) {
-		// Create & register the defined bulks
-		for (XMLParser aBulkRoot : worldRoot.buildSetParser("bulk"))
-			bulkList.add(new Bulk(aSim, aBulkRoot));
+		try {
+			// Create & register the defined bulks
+			for (XMLParser aBulkRoot : worldRoot.buildSetParser("bulk"))
+				bulkList.add(new Bulk(aSim, aBulkRoot));
+		} catch(Exception e) {
+			LogFile.writeLog("Error trying to create bulks in World.init(): "+e);
+		}
 
-		// Create & register the defined domains
-		for (XMLParser aDomainRoot : worldRoot.buildSetParser("computationDomain"))
-			domainList.add(new Domain(aSim, aDomainRoot));
+		try {
+			// Create & register the defined domains
+			for (XMLParser aDomainRoot : worldRoot.buildSetParser("computationDomain"))
+				domainList.add(new Domain(aSim, aDomainRoot));
+		} catch(Exception e){
+			LogFile.writeLog("Error trying to create domains in World.init(): "+e);
+		}
 
 	}
 
@@ -49,6 +58,7 @@ public class World {
 		for (int i = 0; i<domainList.size(); i++) {
 			if (domainList.get(i).getName().equals(cDName)) { return (Domain) domainList.get(i); }
 		}
+		LogFile.writeLog("World.getDomain() found no domain");
 		return null;
 	}
 

--- a/src/simulator/agent/ActiveAgent.java
+++ b/src/simulator/agent/ActiveAgent.java
@@ -303,6 +303,30 @@ public abstract class ActiveAgent extends SpecialisedAgent implements HasReactio
 		
 	}
 	
+	public void updateGrowthRates() {
+	// Rob 30/1/2013: Added so that agent_State outputs will be more accurate
+		double deltaMass = 0;
+		int reacIndex = 0;
+		double catMass = 0; // Catalyst mass
+		_netGrowthRate = 0;
+		_netVolumeRate = 0;
+
+		// Compute mass growth rate of each active reaction
+		for (int iReac = 0; iReac<reactionActive.size(); iReac++) {
+			// Compute the growth rate
+			reacIndex = reactionActive.get(iReac);
+			catMass = particleMass[allReactions[reacIndex]._catalystIndex];
+			// get the growth rate in [fgX.hr-1]
+			growthRate[reacIndex] = allReactions[reacIndex].computeSpecGrowthRate(this);
+
+			for (int i = 0; i<particleYield[reacIndex].length; i++) {
+				deltaMass = catMass * particleYield[reacIndex][i]*growthRate[reacIndex];
+				_netGrowthRate += deltaMass;
+				_netVolumeRate += deltaMass/getSpeciesParam().particleDensity[i];
+			}
+		}
+	}
+	
 	/**
 	 * Take into account all growth
 	 */

--- a/src/simulator/agent/Agent.java
+++ b/src/simulator/agent/Agent.java
@@ -34,7 +34,7 @@ public abstract class Agent implements Cloneable {
 	 * Lineage management
 	 * @field _generation is the number of generations between the progenitor
 	 * and the current agent,
-	 * @field _genealogy is the integer for the binar reading of the 0 and 1
+	 * @field _genealogy is the (long) integer for the binary reading of the 0 and 1
 	 * coding the lineage. When a cells divides, one daughter has the index
 	 * value 1, the other the index value 0, then this index is added on the
 	 * left of the lineage description
@@ -135,7 +135,7 @@ public abstract class Agent implements Cloneable {
 	 */
 	protected void recordGenealogy(Agent baby) {
 		// Rob 18/1/11: Shuffled around slightly to include odd numbers
-		baby._genealogy = _genealogy+ExtraMath.exp2(this._generation);
+		baby._genealogy = _genealogy+ExtraMath.exp2long(this._generation);
 
 		this._generation++;
 		baby._generation = this._generation;

--- a/src/simulator/agent/LocatedAgent.java
+++ b/src/simulator/agent/LocatedAgent.java
@@ -312,6 +312,7 @@ public abstract class LocatedAgent extends ActiveAgent implements Cloneable {
 		baby.registerBirth();
 		baby._netVolumeRate = 0;
 
+		
 	}
 
 	public void divideCompounds(LocatedAgent baby, double babyMassFrac) {
@@ -321,9 +322,12 @@ public abstract class LocatedAgent extends ActiveAgent implements Cloneable {
 			this.particleMass[i] *= 1-babyMassFrac;
 		}
 
-		// Update radius, mass and volumes
+		// Update radius, mass, volumes and growth rates
 		updateSize();
 		baby.updateSize();
+		
+		updateGrowthRates();
+		baby.updateGrowthRates();
 	}
 
 	public void transferCompounds(LocatedAgent baby, double splitRatio) {

--- a/src/simulator/agent/LocatedParam.java
+++ b/src/simulator/agent/LocatedParam.java
@@ -67,7 +67,7 @@ public class LocatedParam extends ActiveParam {
 		value = aSpeciesRoot.getParamDbl("deathRadiusCV");
 		if(!Double.isNaN(value)) deathRadiusCV = value;	
 
-		value = aSpeciesRoot.getParamLength("babyMassFrac ");
+		value = aSpeciesRoot.getParamDbl("babyMassFrac");
 		if(!Double.isNaN(value)) babyMassFrac  = value;
 
 		value = aSpeciesRoot.getParamDbl("babyMassFracCV");

--- a/src/utils/ExtraMath.java
+++ b/src/utils/ExtraMath.java
@@ -81,6 +81,16 @@ public final class ExtraMath {
 	 * @param x
 	 * @return 2^x
 	 */
+	public static final long exp2long(int x) {
+		return (long) Math.pow(2, x);
+	}
+	
+	/**
+	 * power of 2
+	 * 
+	 * @param x
+	 * @return 2^x
+	 */
 	public static final double exp2(double x) {
 		return Math.pow(2, x);
 	}


### PR DESCRIPTION
Various bug fixes and improvements (28 March 2013)

```
results_analysis_matlab/routines2D/creatPics.m
results_analysis_matlab/routines2D/utilities.getProgramPath.m
```

Made the two scripts to be more platform-independent. The booleans ispc
and isunix tell MatLab whether the platform is Windows or Unix-based
(e.g. Linux, Mac) and the corresponding command is called. All other
minor changes stem from this.

```
src/simulator/Simulator.java
```

Removed references to writeInvReport(), a reduced report-writing scheme
for invasion/competition simulations which is now redundant

```
src/simulator/World.java
```

Improved error reporting

```
src/simulator/ActiveAgent.java
src/simulator/LocatedAgent.java
```

Upon cell division, cells now update their growth and volume rates
(approximately half of what they were before). This has no effect on
simulations, but improves reporting

```
src/simulator/Agent.java
src/utils/ExtraMath.java
```

Completion of the update to make _genealogy a long variable

```
build.xml
```

The ant file to compile binaries if the user is not using Eclipse (or
has iDynoMiCS stored remotely on a server which does not have Eclipse)
