### PR TITLE
Agent Death Fix and env_Sum report changes

### DIFF
--- a/src/simulator/SoluteGrid.java
+++ b/src/simulator/SoluteGrid.java
@@ -75,7 +75,6 @@ public class SoluteGrid extends SpatialGrid
 		// Name the grid
 		gridName = xmlRoot.getAttribute("name");
 		
-		
 		// All solute names are stored in a simulation dictionary. Get the position of this solute in this list
 		soluteIndex = aSim.getSoluteIndex(gridName);
 		
@@ -113,6 +112,7 @@ public class SoluteGrid extends SpatialGrid
 		if (Double.isNaN(value)) value = ExtraMath.max(aSim.world.getAllBulkValue(soluteIndex));
 		// Set the grid to this initial concentration
 		setAllValueAt(value);
+		
 	}
 
 

--- a/src/simulator/SpatialGrid.java
+++ b/src/simulator/SpatialGrid.java
@@ -321,7 +321,7 @@ public class SpatialGrid implements Serializable {
 	 * @return	The sum of the values in this spatial grid
 	 */
 	public double getSum() {
-		return MatrixOperations.computeSum(grid);
+		return MatrixOperations.computeSumP(grid);
 	}
 
 	/**
@@ -1012,6 +1012,9 @@ public class SpatialGrid implements Serializable {
 
 		// Close the mark-up
 		bufferState.write("\n</solute>\n");
+		
+		
+		
 
 	}
 

--- a/src/simulator/reaction/Reaction.java
+++ b/src/simulator/reaction/Reaction.java
@@ -102,9 +102,14 @@ public abstract class Reaction implements Serializable
 	protected double[]                _uptakeRate;
 	
 	/**
-	 * Array to store the solute yield from this reaction.  If a solute is not concerned by the current reaction, the yield will be zero
+	 * Array to store the solute yield for this reaction.  If a solute is not concerned by the current reaction, the yield will be zero
 	 */
 	protected double[]                _soluteYield;
+	
+	/**
+	 * Array to store the uptake or production of each solute, by this reaction, for the whole domain [KA August 2013]
+	 */
+	public double[]				  _soluteProductionOrUptake;
 	
 	/**
 	 * Array to store the kinetic factors involved in this reaction
@@ -178,6 +183,7 @@ public abstract class Reaction implements Serializable
 
 		// Initialize arrays storing reaction parameters
 		_soluteYield = new double[nSolute];
+		_soluteProductionOrUptake = new double[nSolute];
 		_particleYield = new double[nParticulate];
 		_particleNameYield = new String[nParticulate];
 
@@ -561,6 +567,23 @@ public abstract class Reaction implements Serializable
 
 		return out;
 	}
+	
+	/**
+	 * \brief Calculates the production or uptake of each solute for this reaction, over the whole domain, for this simulation timestep
+	 * 
+	 * Calculates the production or uptake of each solute for this reaction, over the whole domain, for this simulation timestep. These 
+	 * are totalled for all reactions and written to the env_state files at the appropriate output period
+	 */
+	public void calculateSoluteChange()
+	{
+		// For each solute in the simulation
+		for (int iSolute = 0; iSolute<_soluteList.length; iSolute++) 
+		{
+			// To obtain figure for this solute multiply the sum of the reaction rates by the stochiometry
+			_soluteProductionOrUptake[iSolute] = _soluteYield[iSolute]*getReactionRateSum();
+			
+		}
+	}
 
 	/**
 	 * \brief Write reaction information to the result file stream
@@ -724,6 +747,11 @@ public abstract class Reaction implements Serializable
 	 * @return Marginal diff array
 	 */
 	public abstract double[] computeMarginalDiffMu(double[] s);
+	
+	public double getReactionRateSum()
+	{
+		return _reacGrid.getSum();
+	}
 
 
 }

--- a/src/utils/MatrixOperations.java
+++ b/src/utils/MatrixOperations.java
@@ -200,6 +200,23 @@ public abstract class MatrixOperations
 		return sum;
 	}
 	
+	
+	public static double computeSumP2(double[][][] a) {
+		double sum = 0;
+		for (int i = 1; i<a.length-1; i++)
+			for (int j = 0; j<a[i].length; j++)
+				for (int k = 1; k<a[i][j].length-1; k++)
+				{
+					if(a[i][j][k]!=0)
+					{
+						System.out.println(a[i][j][k]);
+					}
+				
+					sum += a[i][j][k];
+				}
+		return sum;
+	}
+	
 	/**
      * \brief Compute and return the sum of all elements in the grid, padding included
      *


### PR DESCRIPTION
Two changes, one fix one improvement. Fix: Some agents were not being logged in the agent_death files as the list was being cleared at each simulation timestep rather than output period. This has been addressed. Improvement: env_Sum file now lists the global production rate of each solute in that output step, across all reactions.
