### PR TITLE
Added the ability to have species 'defaults' - thus we can now specify

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,10 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="/home/kieran/Dropbox/workspace/iDynoMiCS/bin/lib/Jama-1.0.2.jar"/>
-	<classpathentry kind="lib" path="/home/kieran/Dropbox/workspace/iDynoMiCS/bin/lib/jcommon-1.0.12.jar"/>
-	<classpathentry kind="lib" path="/home/kieran/Dropbox/workspace/iDynoMiCS/bin/lib/jdom.jar"/>
-	<classpathentry kind="lib" path="/home/kieran/Dropbox/workspace/iDynoMiCS/bin/lib/jfreechart-1.0.9.jar"/>
-	<classpathentry kind="lib" path="/home/kieran/Dropbox/workspace/iDynoMiCS/bin/lib/truezip-6.jar"/>
+	<classpathentry kind="lib" path="src/lib/Jama-1.0.2.jar"/>
+	<classpathentry kind="lib" path="src/lib/jcommon-1.0.12.jar"/>
+	<classpathentry kind="lib" path="src/lib/jdom.jar"/>
+	<classpathentry kind="lib" path="src/lib/jfreechart-1.0.9.jar"/>
+	<classpathentry kind="lib" path="src/lib/truezip-6.jar"/>
+	<classpathentry kind="lib" path="src/lib/Update_IDynomics.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/CodeReferenceManualLink
+++ b/CodeReferenceManualLink
@@ -1,1 +1,0 @@
-doxygen/html/index.html

--- a/protocol/examples/single_species_single_substrate_2D.xml
+++ b/protocol/examples/single_species_single_substrate_2D.xml
@@ -54,7 +54,7 @@
 
 		<!-- Attachment scenario - can be 'onetime', where the cells attach to the substratum initially (as in traditional iDynoMiCS)		
 		 or selfattach - where the cells start at the boundary layer and attach after a random walk to the substratum (new from Version 1.2) -->
-		<param name="attachment">selfattach</param>
+		<param name="attachment">onetime</param>
 
 		<!-- The AGENTTIMESTEP which should always be EQUAL or LOWER than the global time step -->
 		<param name="agentTimeStep" unit="hour">0.05</param>
@@ -406,7 +406,7 @@
 			In addition, a maximum biofilm thickness may be given via the 'maxTh' parameter.
 		-->
 		<detachment class="DS_Quadratic">
-			<param name="kDet" unit="um-1.hour-1">5e-6</param>
+			<param name="kDet" unit="um-1.hour-1">5e-5</param>
 			<param name="maxTh" unit="um">200</param>
 		</detachment>
 
@@ -537,7 +537,7 @@
 
 		<reaction name="MyGrowthHeterotrophs" status="active"/>
 
-		<initArea number="2">
+		<initArea number="10">
 			<param name="birthday" unit="hour">0</param>
 			<coordinates x="0" y="132" z="0"/>
 			<coordinates x="10" y="132" z="0"/>

--- a/src/simulator/Simulator.java
+++ b/src/simulator/Simulator.java
@@ -827,11 +827,15 @@ public class Simulator
 		{ 
 			System.out.print("\t Species: \n");
 			
+			// Read in the 'Species Defaults' from the parameter file
+			XMLParser speciesDefaults = new XMLParser(_protocolFile.getChildElement("speciesDefaults"));
+			
+			
 			// Now iterate through all species specified in the protocol file
 			for (Element aSpeciesMarkUp : _protocolFile.buildSetMarkUp("species")) 
 			{
 				// Create a new species object for this specification
-				Species aSpecies = new Species(this, new XMLParser(aSpeciesMarkUp)); 
+				Species aSpecies = new Species(this, new XMLParser(aSpeciesMarkUp),speciesDefaults); 
 				// Add to the list of species in this simulation
 				speciesList.add(aSpecies);
 				

--- a/src/simulator/agent/ActiveParam.java
+++ b/src/simulator/agent/ActiveParam.java
@@ -67,10 +67,10 @@ public class ActiveParam extends SpeciesParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A Species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) 
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) 
 	{
 		// Initialize simple parameter
-		super.init(aSim, aSpeciesRoot);
+		super.init(aSim, aSpeciesRoot,speciesDefaults);
 
 		// Initialize particulateDensity table
 		int nParticle = aSim.particleDic.size();

--- a/src/simulator/agent/LocatedParam.java
+++ b/src/simulator/agent/LocatedParam.java
@@ -109,49 +109,53 @@ public class LocatedParam extends ActiveParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A Species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) 
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) 
 	{
-		super.init(aSim, aSpeciesRoot);
+		super.init(aSim, aSpeciesRoot, speciesDefaults);
 		double value;
 
 		//sonia 28.04.2010
 		//the user can define the degree of variability in the division, split and death radius
 		//by defining the "parameterCV" in the protocol file
 
-		value = aSpeciesRoot.getParamLength("divRadius");
+		// AUGUST 2013 - Change such that these can be declared as defaults, rather than for EVERY species
+		// But can be overriden for each species, so need to check if in species - if not then check the defaults
+		// If not in defaults, the default value hard coded into iDynoMiCS (if present) will be used
+		
+		value = getSpeciesParameterLength("divRadius",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) divRadius = value;
-
-		value = aSpeciesRoot.getParamDbl("divRadiusCV");
+		
+		value = getSpeciesParameterDouble("divRadiusCV",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) divRadiusCV = value;
-
-		value = aSpeciesRoot.getParamLength("deathRadius");
+		
+		value = getSpeciesParameterLength("deathRadius",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) deathRadius = value;
 
-		value = aSpeciesRoot.getParamDbl("deathRadiusCV");
-		if(!Double.isNaN(value)) deathRadiusCV = value;	
+		value = getSpeciesParameterDouble("deathRadiusCV",aSpeciesRoot,speciesDefaults);
+		if(!Double.isNaN(value)) deathRadiusCV = value;
 
-		value = aSpeciesRoot.getParamDbl("babyMassFrac ");
-		if(!Double.isNaN(value)) babyMassFrac  = value;
+		value = getSpeciesParameterDouble("babyMassFrac",aSpeciesRoot,speciesDefaults);
+		if(!Double.isNaN(value)) babyMassFrac = value;
 
-		value = aSpeciesRoot.getParamDbl("babyMassFracCV");
-		if(!Double.isNaN(value)) babyMassFracCV = value;	
-
-		value = aSpeciesRoot.getParamLength("shoveLimit");
+		value = getSpeciesParameterDouble("babyMassFracCV",aSpeciesRoot,speciesDefaults);
+		if(!Double.isNaN(value)) babyMassFracCV = value;
+	
+		value = getSpeciesParameterLength("shoveLimit",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) shoveLimit = value;
 
-		value = aSpeciesRoot.getParamLength("shoveFactor");
-		if(!Double.isNaN(value)) shoveFactor = value;		
+		value = getSpeciesParameterLength("shoveFactor",aSpeciesRoot,speciesDefaults);
+		if(!Double.isNaN(value)) shoveFactor = value;
 		
 		// Attachment parameters - KA 170513
-		value = aSpeciesRoot.getParamLength("cellRunSpeed");
+		value = getSpeciesParameterLength("cellRunSpeed",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) cellRunSpeed = value;
-				
-		value = aSpeciesRoot.getParamLength("tumbleInt");
+		
+		value = getSpeciesParameterLength("tumbleInt",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) tumbleInterval = value;
-			
-		value = aSpeciesRoot.getParamLength("stickinessAddition");
+				
+		value = getSpeciesParameterLength("stickinessAddition",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) stickinessAddition = value;
-			
+		
 	}
 	
 	/**

--- a/src/simulator/agent/Species.java
+++ b/src/simulator/agent/Species.java
@@ -133,7 +133,7 @@ public class Species implements Serializable
 	 * @param aSimulator	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpRoot	A Species mark-up within the specified protocol file
 	 */
-	public Species(Simulator aSimulator, XMLParser aSpRoot) 
+	public Species(Simulator aSimulator, XMLParser aSpRoot, XMLParser speciesDefaults) 
 	{
 		// Name of the species as specified in the protocol file
 		speciesName = aSpRoot.getAttribute("name");
@@ -164,12 +164,13 @@ public class Species implements Serializable
 		_progenitor = (SpecialisedAgent) aSpRoot.instanceCreator("simulator.agent.zoo");
 		// Get parameters for this progenitor object from the protocol file if present
 
-		_progenitor.getSpeciesParam().init(aSimulator, aSpRoot);
+		_progenitor.getSpeciesParam().init(aSimulator, aSpRoot, speciesDefaults);
 		
 		_progenitor.setSpecies(this);
 
 		// Set the computational domain this species is associated with
-		domain = aSimulator.world.getDomain(aSpRoot.getParam("computationDomain"));
+		// KA Aug 13 - changed as this may be a default
+		domain = aSimulator.world.getDomain(_progenitor.getSpeciesParam().getSpeciesParameterString("computationDomain", aSpRoot, speciesDefaults));
 	}
 
 	/**

--- a/src/simulator/agent/SpeciesParam.java
+++ b/src/simulator/agent/SpeciesParam.java
@@ -32,11 +32,63 @@ public class SpeciesParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A Species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) 
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) 
 	{
 		double value;
-		value = aSpeciesRoot.getParamDbl("initialMassCV");
+		
+		// August 2013 - changed as this now may be specified in the species defaults and not for each species
+		// So use the new method
+		value = getSpeciesParameterDouble("initialMassCV",aSpeciesRoot,speciesDefaults);
 		if(!Double.isNaN(value)) initialMassCV = value;
+		
+	}
+	
+	public double getSpeciesParameterLength(String paramName, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
+	{
+		if(!Double.isNaN(aSpeciesRoot.getParamLength(paramName)))
+		{
+			return aSpeciesRoot.getParamLength(paramName);
+		}
+		else if(!Double.isNaN(speciesDefaults.getParamLength(paramName)))
+		{
+			return speciesDefaults.getParamLength(paramName);
+		}
+		else
+		{
+			return Double.NaN;
+		}
+	}
+	
+	public double getSpeciesParameterDouble(String paramName, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
+	{
+		if(!Double.isNaN(aSpeciesRoot.getParamDbl(paramName)))
+		{
+			return aSpeciesRoot.getParamDbl(paramName);
+		}
+		else if(!Double.isNaN(speciesDefaults.getParamDbl(paramName)))
+		{
+			return speciesDefaults.getParamDbl(paramName);
+		}
+		else
+		{
+			return Double.NaN;
+		}
+	}
+	
+	public String getSpeciesParameterString(String paramName, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
+	{
+		if(aSpeciesRoot.getParam(paramName)!= null)
+		{
+			return aSpeciesRoot.getParam(paramName);
+		}
+		else if(speciesDefaults.getParam(paramName)!= null)
+		{
+			return speciesDefaults.getParam(paramName);
+		}
+		else
+		{
+			return null;
+		}
 	}
 
 

--- a/src/simulator/agent/zoo/BactAdaptableParam.java
+++ b/src/simulator/agent/zoo/BactAdaptableParam.java
@@ -108,11 +108,11 @@ public class BactAdaptableParam extends BactEPSParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot)
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
 	{
 		String colorName;
 
-		super.init(aSim,aSpeciesRoot);
+		super.init(aSim,aSpeciesRoot,speciesDefaults);
 
 		// Now take care of reaction switch business
 		int reacIndex;

--- a/src/simulator/agent/zoo/BactEPSParam.java
+++ b/src/simulator/agent/zoo/BactEPSParam.java
@@ -45,9 +45,9 @@ public class BactEPSParam extends BacteriumParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot)
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
 	{
-		super.init(aSim,aSpeciesRoot);
+		super.init(aSim,aSpeciesRoot,speciesDefaults);
 		double value;
 
 		value = aSpeciesRoot.getParamDbl("kHyd");

--- a/src/simulator/agent/zoo/BacteriumParam.java
+++ b/src/simulator/agent/zoo/BacteriumParam.java
@@ -64,9 +64,9 @@ public class BacteriumParam extends LocatedParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot)
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults)
 	{
-		super.init(aSim,aSpeciesRoot);
+		super.init(aSim,aSpeciesRoot,speciesDefaults);
 		double value;
 
 		value = aSpeciesRoot.getParamDbl("epsMax");

--- a/src/simulator/agent/zoo/EpiBacEnvParam.java
+++ b/src/simulator/agent/zoo/EpiBacEnvParam.java
@@ -35,8 +35,8 @@ public class EpiBacEnvParam extends MultiEpiBacParam{
 	}
 	
 	
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) {
-		super.init(aSim, aSpeciesRoot);
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) {
+		super.init(aSim, aSpeciesRoot, speciesDefaults);
 
 	
 	//retrieving list of environments to which this species is sensitive to and the correspondent

--- a/src/simulator/agent/zoo/EpiBacParam.java
+++ b/src/simulator/agent/zoo/EpiBacParam.java
@@ -35,8 +35,8 @@ public class EpiBacParam extends BactEPSParam {
 		super();
 	}
 
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) {
-		super.init(aSim, aSpeciesRoot);
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) {
+		super.init(aSim, aSpeciesRoot,speciesDefaults);
 		String colorName;
 
 		scanSpeed = aSpeciesRoot.getParamDbl("scanSpeed");

--- a/src/simulator/agent/zoo/MultiEpiBacParam.java
+++ b/src/simulator/agent/zoo/MultiEpiBacParam.java
@@ -48,8 +48,8 @@ import utils.*;
 		super();
 	}
 
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) {
-		super.init(aSim, aSpeciesRoot);
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) {
+		super.init(aSim, aSpeciesRoot, speciesDefaults);
 		double value;
 
 		value = aSpeciesRoot.getParamDbl("donorProbability");

--- a/src/simulator/agent/zoo/ParticulateEPSParam.java
+++ b/src/simulator/agent/zoo/ParticulateEPSParam.java
@@ -52,10 +52,10 @@ public class ParticulateEPSParam extends LocatedParam
 	 * @param aSim	The simulation object used to simulate the conditions specified in the protocol file
 	 * @param aSpeciesRoot	A species mark-up within the specified protocol file
 	 */
-	public void init(Simulator aSim, XMLParser aSpeciesRoot) 
+	public void init(Simulator aSim, XMLParser aSpeciesRoot, XMLParser speciesDefaults) 
 	{
 		double value;
-		super.init(aSim, aSpeciesRoot);
+		super.init(aSim, aSpeciesRoot, speciesDefaults);
 
 		value = aSpeciesRoot.getParamLength("transferRadius");
 		if(!Double.isNaN(value)) transferRadius = value;


### PR DESCRIPTION
Added the ability to have species 'defaults' - thus we can now specify computationDomain, divRadius, divRadiusCV, deathRadius, deathRadiusCV, babyMassFrac, babyMassFracCV, shoveFactor and shoveLimit within the tag <speciesDefaults>. Thus if the same are being used for a number of species, these now only need to be declared once in the protocol file
