### PR TITLE
Bugfix: New speciesDefault XMLParser error

### DIFF
--- a/src/simulator/Simulator.java
+++ b/src/simulator/Simulator.java
@@ -826,9 +826,17 @@ public class Simulator
 		try 
 		{ 
 			System.out.print("\t Species: \n");
-			
+
+			XMLParser speciesDefaults;
 			// Read in the 'Species Defaults' from the parameter file
-			XMLParser speciesDefaults = new XMLParser(_protocolFile.getChildElement("speciesDefaults"));
+			if(_protocolFile.getChildElement("speciesDefaults") != null)
+			{
+			    speciesDefaults = new XMLParser(_protocolFile.getChildElement("speciesDefaults"));
+			}
+			else
+			{
+				speciesDefaults = new XMLParser(new Element("speciesDefaults"));
+			}
 			
 			
 			// Now iterate through all species specified in the protocol file


### PR DESCRIPTION
### How to reproduce

Run a simulation form `single_species_single_substrate_2D.xml` or any protocol file which does not have a `<speciesDefault>` section. 
### Expected behaviour

Simulation runs without throwing an exception.
### Actual behaviour

An exception is thrown due to referencing a null `Element` in the protocol file. This error is not reported.

```
Error in Simulator.createSpecies() first stage
         Agent Grid:
Agent time step is... 0.05
Error in Simulator.createSpecies() second stage
java.lang.ArrayIndexOutOfBoundsException: 0
        at simulator.AgentContainer.createOutputGrid(AgentContainer.java:1655)
        at simulator.AgentContainer.<init>(AgentContainer.java:270)
        at simulator.Simulator.createSpecies(Simulator.java:863)
        at simulator.Simulator.<init>(Simulator.java:272)
        at idyno.Idynomics.initSimulation(Idynomics.java:567)
        at idyno.Idynomics.startIDynomics(Idynomics.java:315)
        at idyno.Idynomics.main(Idynomics.java:200)
         Species populations:
Simulator.CreateSystem(): error met: java.lang.NullPointerException
java.lang.NullPointerException
        at simulator.Simulator.oneTimeAttachmentAgentBirth(Simulator.java:1042)
        at simulator.Simulator.checkAgentBirth(Simulator.java:1010)
        at simulator.Simulator.createSpecies(Simulator.java:922)
        at simulator.Simulator.<init>(Simulator.java:272)
        at idyno.Idynomics.initSimulation(Idynomics.java:567)
        at idyno.Idynomics.startIDynomics(Idynomics.java:315)
        at idyno.Idynomics.main(Idynomics.java:200)
```
### Fix
- Add a stack trace to the `catch` expression in the first phase of `createSpecies`
- Test if speciesDefault exists in the protocol file, and if not replace it with an empty Element.
