### PR TITLE
Fix SimpleInhibition

### DIFF
--- a/src/simulator/reaction/kinetic/SimpleInhibition.java
+++ b/src/simulator/reaction/kinetic/SimpleInhibition.java
@@ -32,19 +32,6 @@ public class SimpleInhibition extends IsKineticFactor
 	 * Half maximum concentration of the solute
 	 */
 	private double _Ki;
-
-	/**
-	 * \brief Constructor to set kinetic parameters to the supplied values
-	 * 
-	 * Constructor to set kinetic parameters to the supplied values
-	 * 
-	 * @param Ki	Concentration of solute
-	 */
-	public SimpleInhibition(double Ki)
-	{
-		_Ki = Ki;
-		nParam = 1;
-	}
 	
 	/**
 	 * \brief Initialise the kinetic, reading in kinetic parameter information from the protocol file and calculating any auxillaries needed for easing the kinetic calculation


### PR DESCRIPTION
SimpleInhibition looks to have been broken since [9283eb5d](https://github.com/kreft/iDynoMiCS/blob/9283eb5d7e9b34161adf49f9491870a2fcf641ba/src/simulator/reaction/kinetic/SimpleInhibition.java) when the default constructor was removed, leaving the constructor with one argument. The lack of default constructor means that XMLParser.instanceCreator cannot create the class when it is specified in the protocol file, and "Unable to create class" is written to the log.

The single argument constructor is not used anywhere, so I have removed it which allows default construction of SimpleInhibition, and fixes the problem.
